### PR TITLE
feat: カテゴリ個別固定機能を実装

### DIFF
--- a/prisma/migrations/20260227000000_add_category_is_overridden/migration.sql
+++ b/prisma/migrations/20260227000000_add_category_is_overridden/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `transactions` ADD COLUMN `category_is_overridden` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,8 +77,9 @@ model Transaction {
   type           String        // "expense" | "income" | "transfer"
   categoryId     Int?          @map("category_id")
   dataSourceId   Int?          @map("data_source_id")
-  isShared       Boolean       @default(false) @map("is_shared")
-  settlementDate DateTime?     @map("settlement_date")
+  isShared              Boolean       @default(false) @map("is_shared")
+  categoryIsOverridden  Boolean       @default(false) @map("category_is_overridden")
+  settlementDate        DateTime?     @map("settlement_date")
   hashKey          String        @unique @map("hash_key")
   receiptImageUrl  String?       @map("receipt_image_url")
   user             User          @relation(fields: [userId], references: [id])

--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -80,7 +80,15 @@ export default async function TransactionsPage({
         ...(parsedDataSourceId ? { dataSourceId: parsedDataSourceId } : {}),
         ...(isShared === "1" ? { isShared: true } : {}),
       },
-      include: {
+      select: {
+        id: true,
+        usageDate: true,
+        amount: true,
+        description: true,
+        type: true,
+        isShared: true,
+        categoryIsOverridden: true,
+        receiptImageUrl: true,
         category: { select: { id: true, name: true } },
         dataSource: { select: { id: true, name: true } },
         receiptItems: {


### PR DESCRIPTION
- Transactionモデルに category_is_overridden フラグを追加
- 一括カテゴリ更新時、固定済み明細をスキップするよう修正
- 個別明細のカテゴリ変更・固定操作用のサーバーアクションを追加
  - updateSingleTransactionCategory: 1件のみ更新し固定フラグをON
  - setCategoryOverride: カテゴリ変更なしで固定フラグのみON
  - clearCategoryOverride: 固定フラグをOFF（一括更新の対象に戻す）
- TransactionTable UIに固定トグルボタンを追加
  - 通常行: ホバー時のみ鍵アイコンを表示（UXを邪魔しない）
  - 固定行: 青い鍵アイコン常時表示 + 枠線を青色に変更
  - 固定行のSelectはこの明細のみ更新、非固定行は一括更新

https://claude.ai/code/session_01Fr2kbmVwm3e4t6GjYNgTa7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lock individual transaction categories to exclude them from bulk updates, enabling precise control over category assignments.
  * Locked transactions are visually distinguished with a distinct colored border indicator for easy identification.
  * Lock/unlock toggle button per transaction lets you easily manage which items are affected by bulk category changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->