### PR TITLE
feat: 一括カテゴリ設定時にCategoryRuleを保存し、インポート時に自動適用する

### DIFF
--- a/src/lib/actions/csv.ts
+++ b/src/lib/actions/csv.ts
@@ -90,6 +90,10 @@ export async function importTransactions(
 
   const { transactions, cardHolderUserMap, defaultUserId, dataSourceId } = payload;
 
+  // CategoryRule を取得して description → categoryId のマップを作る
+  const rules = await prisma.categoryRule.findMany();
+  const ruleMap = new Map(rules.map((r) => [r.keyword, r.categoryId]));
+
   const data = transactions.map((t) => ({
     userId:
       t.cardHolder !== undefined
@@ -101,6 +105,7 @@ export async function importTransactions(
     type: t.type,
     hashKey: t.hashKey,
     ...(dataSourceId !== undefined ? { dataSourceId } : {}),
+    ...(ruleMap.has(t.description) ? { categoryId: ruleMap.get(t.description) } : {}),
   }));
 
   const result = await prisma.transaction.createMany({


### PR DESCRIPTION
- updateTransactionCategory: categoryId != null のとき CategoryRule を upsert
- importTransactions: CategoryRule を取得し、description がマッチした明細に categoryId を自動設定

https://claude.ai/code/session_01BAJSNAxy65KNALjty2u4dL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transactions during import are now automatically assigned matching category rules based on description keywords.
  * Category rules are automatically created when you assign categories to transactions, enabling future automatic categorization.

* **Security**
  * Authentication is now required before updating transaction categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->