### PR TITLE
fix(transactions): 振替金額の表示色を緑からグレーに変更

### DIFF
--- a/src/app/(app)/transactions/_components/TransactionTable.tsx
+++ b/src/app/(app)/transactions/_components/TransactionTable.tsx
@@ -235,8 +235,10 @@ export default function TransactionTable({ transactions, categories }: Props) {
               <span className="font-mono font-semibold whitespace-nowrap text-sm shrink-0">
                 {t.type === "expense" ? (
                   <span className="text-red-400">-¥{Math.abs(t.amount).toLocaleString()}</span>
-                ) : (
+                ) : t.type === "income" ? (
                   <span className="text-green-500">¥{Math.abs(t.amount).toLocaleString()}</span>
+                ) : (
+                  <span className="text-gray-400">¥{Math.abs(t.amount).toLocaleString()}</span>
                 )}
               </span>
             </div>
@@ -446,8 +448,10 @@ export default function TransactionTable({ transactions, categories }: Props) {
                 <TableCell className="text-right whitespace-nowrap text-sm font-mono">
                   {t.type === "expense" ? (
                     <span className="text-red-400">-¥{Math.abs(t.amount).toLocaleString()}</span>
-                  ) : (
+                  ) : t.type === "income" ? (
                     <span className="text-green-500">¥{Math.abs(t.amount).toLocaleString()}</span>
+                  ) : (
+                    <span className="text-gray-400">¥{Math.abs(t.amount).toLocaleString()}</span>
                   )}
                 </TableCell>
                 <TableCell className="text-center">


### PR DESCRIPTION
## Summary
- 明細一覧で振替（transfer）の金額が収入（income）と同じ緑色で表示されていた問題を修正
- 振替の金額色を `text-green-500` → `text-gray-400` に変更
- モバイル表示・デスクトップ表示の両方を修正

## Test plan
- [ ] `/transactions` を開き、振替（transfer）行の金額がグレー表示になることを確認
- [ ] 収入（income）が引き続き緑色で表示されることを確認
- [ ] 支出（expense）が引き続き赤色で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced transaction amount display to properly handle all transaction types with consistent formatting across mobile and desktop views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->