### PR TITLE
feat: searchTransactions 追加 + 明細一覧キーワード検索 (#13)

### DIFF
--- a/src/app/(app)/transactions/page.tsx
+++ b/src/app/(app)/transactions/page.tsx
@@ -16,12 +16,13 @@ export default async function TransactionsPage({
     type?: string;
     dataSourceId?: string;
     isShared?: string;
+    keyword?: string;
   }>;
 }) {
   const session = await auth();
   if (!session?.user) redirect("/auth/signin");
 
-  const { monthFrom, monthTo, categoryIds, type, dataSourceId, isShared } =
+  const { monthFrom, monthTo, categoryIds, type, dataSourceId, isShared, keyword } =
     await searchParams;
 
   const allDates = await prisma.transaction.findMany({
@@ -79,6 +80,7 @@ export default async function TransactionsPage({
         ...(type ? { type } : {}),
         ...(parsedDataSourceId ? { dataSourceId: parsedDataSourceId } : {}),
         ...(isShared === "1" ? { isShared: true } : {}),
+        ...(keyword ? { description: { contains: keyword } } : {}),
       },
       select: {
         id: true,
@@ -149,6 +151,7 @@ export default async function TransactionsPage({
           dataSources={dataSources}
           selectedDataSourceId={dataSourceId ?? ""}
           isSharedFilter={isShared === "1"}
+          keyword={keyword ?? ""}
         />
       </Suspense>
       <TransactionTable transactions={transactions} categories={categories} />

--- a/src/app/api/transactions/csv/route.ts
+++ b/src/app/api/transactions/csv/route.ts
@@ -32,6 +32,7 @@ export async function GET(request: NextRequest) {
   const type = searchParams.get("type") ?? "";
   const dataSourceId = searchParams.get("dataSourceId") ?? "";
   const isShared = searchParams.get("isShared") ?? "";
+  const keyword = searchParams.get("keyword") ?? "";
 
   const categoryIdList = categoryIds
     ? categoryIds
@@ -73,6 +74,7 @@ export async function GET(request: NextRequest) {
       ...(type ? { type } : {}),
       ...(parsedDataSourceId ? { dataSourceId: parsedDataSourceId } : {}),
       ...(isShared === "1" ? { isShared: true } : {}),
+      ...(keyword ? { description: { contains: keyword } } : {}),
     },
     include: {
       category: { select: { name: true } },


### PR DESCRIPTION
## Summary

- Gemini Function Calling に `searchTransactions` を追加。キーワード・日付範囲・金額範囲・種別・カテゴリなど複数条件で明細を検索できる
- `/transactions` 画面に摘要キーワード検索フィールドを追加（400ms デバウンスで自動検索、Enter 不要）
- キーワードフィルタを CSV 出力 API にも反映（フィルタ済み内容がそのまま出力される）

## Changes

| File | 変更内容 |
|------|---------|
| `src/lib/gemini-advice.ts` | `searchTransactions` Function Declaration・型・switch case 追加 |
| `src/app/(app)/transactions/page.tsx` | `keyword` searchParam 対応・Prisma where 句追加 |
| `src/app/(app)/transactions/_components/TransactionFilters.tsx` | キーワード検索 UI（デバウンス付き）追加 |
| `src/app/api/transactions/csv/route.ts` | `keyword` フィルタ追加 |

## Code Quality (simplify)

- `buildDateRange` を year-only 対応に拡張して重複ロジック削除
- PC/モバイルの Input+Button 重複を `KeywordInput` コンポーネントに抽出
- `type` キャストに `TransactionType` を使用

## Test plan

- [ ] `/transactions` でキーワード入力 → 400ms 後に URL に反映され自動絞り込み
- [ ] ✕ ボタンでキーワード解除
- [ ] 他フィルタ（月・カテゴリ・種別）との AND 組み合わせ動作確認
- [ ] キーワード絞り込み状態で CSV ダウンロード → 絞り込まれた内容が出力される
- [ ] `/advice` で「スーパーという店を探して」→ Gemini が `searchTransactions` を呼び出す
- [ ] `npm run test` 全グリーン ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyword search to filter transactions by description across the app
  * Keyword filters are applied to CSV exports
  * Enhanced AI-powered transaction search with support for multiple filter parameters including date range, amount, type, and category

<!-- end of auto-generated comment: release notes by coderabbit.ai -->