### PR TITLE
feat(monthly): 月別サマリー画面を追加 (#22)

### DIFF
--- a/src/app/(app)/monthly/_components/CategoryBreakdownChart.tsx
+++ b/src/app/(app)/monthly/_components/CategoryBreakdownChart.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Cell,
+  LabelList,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useAccentColor } from "@/components/AccentColorProvider";
+import type { ChartEntry } from "../page";
+
+const BASE_COLORS = [
+  "#2aa4a4",
+  "#3a5a7a",
+  "#c9a832",
+  "#c47a1a",
+  "#7a5a3a",
+  "#5a7a3a",
+];
+const PX_PER_CHAR = 13;
+const RIGHT_MARGIN = 130;
+
+type Props = {
+  chartData: ChartEntry[];
+  selectedCategoryId: number | null | undefined;
+  onSelectCategory: (categoryId: number | null) => void;
+};
+
+export default function CategoryBreakdownChart({
+  chartData,
+  selectedCategoryId,
+  onSelectCategory,
+}: Props) {
+  const { accentColor } = useAccentColor();
+  const CHART_COLORS = [accentColor, ...BASE_COLORS];
+
+  if (chartData.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">カテゴリ別支出</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center justify-center h-48 text-sm text-muted-foreground">
+          データがありません
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { yAxisWidth, chartHeight } = useMemo(() => {
+    const maxChars = Math.max(...chartData.map((d) => [...d.name].length));
+    return {
+      yAxisWidth: Math.max(48, maxChars * PX_PER_CHAR + 4),
+      chartHeight: Math.max(160, chartData.length * 40),
+    };
+  }, [chartData]);
+  const hasSelection = selectedCategoryId !== undefined;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">
+          カテゴリ別支出
+          <span className="ml-2 text-xs font-normal text-muted-foreground">
+            バーをクリックすると明細を表示
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={chartHeight}>
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 0, right: RIGHT_MARGIN, left: 0, bottom: 0 }}
+          >
+            <XAxis type="number" hide />
+            <YAxis
+              type="category"
+              dataKey="name"
+              width={yAxisWidth}
+              tick={{ fontSize: 12 }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <Bar
+              dataKey="amount"
+              radius={[0, 4, 4, 0]}
+              onClick={(data) => onSelectCategory((data as unknown as ChartEntry).categoryId)}
+              style={{ cursor: "pointer" }}
+            >
+              {chartData.map((entry, index) => (
+                <Cell
+                  key={index}
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                  opacity={
+                    hasSelection && selectedCategoryId !== entry.categoryId ? 0.35 : 1
+                  }
+                />
+              ))}
+              <LabelList
+                dataKey="amount"
+                content={(props) => {
+                  const { x, y, width, height, value, index } = props as {
+                    x: number;
+                    y: number;
+                    width: number;
+                    height: number;
+                    value: number;
+                    index: number;
+                  };
+                  if (index == null) return null;
+                  const entry = chartData[index];
+                  if (!entry) return null;
+                  return (
+                    <text
+                      x={(x ?? 0) + (width ?? 0) + 4}
+                      y={(y ?? 0) + (height ?? 0) / 2}
+                      dominantBaseline="central"
+                      fontSize={11}
+                      fill="#888"
+                    >
+                      {`¥${entry.amount.toLocaleString("ja-JP")} (${entry.percentage}%)`}
+                    </text>
+                  );
+                }}
+              />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/monthly/_components/CategoryTransactionTable.tsx
+++ b/src/app/(app)/monthly/_components/CategoryTransactionTable.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useMemo } from "react";
+import { X } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { TransactionItem } from "../page";
+
+type Props = {
+  transactions: TransactionItem[];
+  selectedCategoryId: number | null;
+  categoryName: string;
+  onClose: () => void;
+};
+
+function formatDate(d: Date): string {
+  const date = new Date(d);
+  return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, "0")}/${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export default function CategoryTransactionTable({
+  transactions,
+  selectedCategoryId,
+  categoryName,
+  onClose,
+}: Props) {
+  const { filtered, subtotal } = useMemo(() => {
+    const f = transactions
+      .filter((t) => t.categoryId === selectedCategoryId && t.type === "expense")
+      .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+    return { filtered: f, subtotal: f.reduce((sum, t) => sum + t.amount, 0) };
+  }, [transactions, selectedCategoryId]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">
+            {categoryName} の明細
+            <span className="ml-2 text-sm font-normal text-muted-foreground">
+              {filtered.length}件 / 合計: ¥{subtotal.toLocaleString()}
+            </span>
+          </CardTitle>
+          <button
+            onClick={onClose}
+            className="rounded p-1 hover:bg-muted transition-colors shrink-0"
+            aria-label="閉じる"
+          >
+            <X className="size-4 text-muted-foreground" />
+          </button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {/* モバイル: カードリスト */}
+        <div className="md:hidden space-y-2">
+          {filtered.length === 0 && (
+            <p className="text-center text-muted-foreground py-4 text-sm">
+              明細がありません
+            </p>
+          )}
+          {filtered.map((t) => (
+            <div key={t.id} className="rounded-lg border bg-muted/30 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs text-muted-foreground">
+                  {formatDate(t.usageDate)}
+                </span>
+                <span className="font-mono text-sm font-semibold text-red-400">
+                  -¥{Math.abs(t.amount).toLocaleString()}
+                </span>
+              </div>
+              <p className="mt-1 text-sm truncate">{t.description}</p>
+              {t.dataSource && (
+                <p className="mt-0.5 text-xs text-muted-foreground">{t.dataSource.name}</p>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* デスクトップ: テーブル */}
+        <div className="hidden md:block rounded-md border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="whitespace-nowrap">日付</TableHead>
+                <TableHead>説明</TableHead>
+                <TableHead className="whitespace-nowrap">データソース</TableHead>
+                <TableHead className="text-right whitespace-nowrap">金額</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.length === 0 && (
+                <TableRow>
+                  <TableCell
+                    colSpan={4}
+                    className="text-center text-muted-foreground py-4"
+                  >
+                    明細がありません
+                  </TableCell>
+                </TableRow>
+              )}
+              {filtered.map((t) => (
+                <TableRow key={t.id}>
+                  <TableCell className="whitespace-nowrap text-sm">
+                    {formatDate(t.usageDate)}
+                  </TableCell>
+                  <TableCell className="max-w-[200px] truncate text-sm">
+                    {t.description}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                    {t.dataSource?.name ?? "—"}
+                  </TableCell>
+                  <TableCell className="text-right whitespace-nowrap font-mono text-sm text-red-400">
+                    -¥{Math.abs(t.amount).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/monthly/_components/DataSourceFilter.tsx
+++ b/src/app/(app)/monthly/_components/DataSourceFilter.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+type DataSourceOption = { id: number; name: string };
+
+type Props = {
+  allDataSources: DataSourceOption[];
+  selectedIds: number[];
+  year: number;
+  month: number;
+};
+
+export default function DataSourceFilter({
+  allDataSources,
+  selectedIds,
+  year,
+  month,
+}: Props) {
+  const router = useRouter();
+  const selectedSet = new Set(selectedIds);
+
+  function push(ids: Set<number>) {
+    const params = new URLSearchParams({ year: String(year), month: String(month) });
+    if (ids.size > 0) params.set("dataSources", [...ids].join(","));
+    router.push(`/monthly?${params.toString()}`);
+  }
+
+  function handleToggle(id: number, checked: boolean) {
+    const current = new Set(selectedIds);
+    if (checked) current.add(id);
+    else current.delete(id);
+    push(current);
+  }
+
+  function handleClear() {
+    push(new Set());
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="justify-between font-normal">
+          {selectedIds.length === 0
+            ? "データソース: 全て"
+            : `${selectedIds.length} データソース選択中`}
+          <ChevronDown className="size-4 opacity-50 ml-2" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-52 p-2" align="start">
+        <button
+          onClick={handleClear}
+          className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+        >
+          すべてクリア
+        </button>
+        <div className="max-h-60 overflow-y-auto space-y-1 mt-1">
+          {allDataSources.length === 0 && (
+            <p className="text-sm text-muted-foreground px-2 py-1">データソースなし</p>
+          )}
+          {allDataSources.map((ds) => (
+            <label
+              key={ds.id}
+              className="flex items-center gap-2 px-2 py-1 rounded hover:bg-accent cursor-pointer"
+            >
+              <Checkbox
+                checked={selectedSet.has(ds.id)}
+                onCheckedChange={(checked) => handleToggle(ds.id, Boolean(checked))}
+              />
+              <span className="text-sm">{ds.name}</span>
+            </label>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/app/(app)/monthly/_components/MonthlyClientShell.tsx
+++ b/src/app/(app)/monthly/_components/MonthlyClientShell.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import CategoryBreakdownChart from "./CategoryBreakdownChart";
+import CategoryTransactionTable from "./CategoryTransactionTable";
+import type { ChartEntry, TransactionItem } from "../page";
+
+type Props = {
+  chartData: ChartEntry[];
+  transactions: TransactionItem[];
+};
+
+export default function MonthlyClientShell({ chartData, transactions }: Props) {
+  // undefined = 未選択, null = 未分類カテゴリ, number = カテゴリID
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null | undefined>(
+    undefined
+  );
+
+  function handleSelectCategory(categoryId: number | null) {
+    setSelectedCategoryId((prev) => (prev === categoryId ? undefined : categoryId));
+  }
+
+  const selectedEntry = chartData.find((d) => d.categoryId === selectedCategoryId);
+
+  return (
+    <div className="space-y-4">
+      <CategoryBreakdownChart
+        chartData={chartData}
+        selectedCategoryId={selectedCategoryId}
+        onSelectCategory={handleSelectCategory}
+      />
+      {selectedCategoryId !== undefined && (
+        <CategoryTransactionTable
+          transactions={transactions}
+          selectedCategoryId={selectedCategoryId}
+          categoryName={selectedEntry?.name ?? "未分類"}
+          onClose={() => setSelectedCategoryId(undefined)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/monthly/_components/MonthlyHeader.tsx
+++ b/src/app/(app)/monthly/_components/MonthlyHeader.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  year: number;
+  month: number;
+  dataSources: string;
+};
+
+function offsetMonth(year: number, month: number, delta: number) {
+  const d = new Date(year, month - 1 + delta, 1);
+  return { year: d.getFullYear(), month: d.getMonth() + 1 };
+}
+
+export default function MonthlyHeader({ year, month, dataSources }: Props) {
+  const router = useRouter();
+
+  function navigate(delta: number) {
+    const { year: y, month: m } = offsetMonth(year, month, delta);
+    const params = new URLSearchParams({ year: String(y), month: String(m) });
+    if (dataSources) params.set("dataSources", dataSources);
+    router.push(`/monthly?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="icon" onClick={() => navigate(-1)} aria-label="前月">
+        <ChevronLeft className="size-4" />
+      </Button>
+      <span className="text-lg font-semibold min-w-[7rem] text-center">
+        {year}年{month}月
+      </span>
+      <Button variant="outline" size="icon" onClick={() => navigate(1)} aria-label="次月">
+        <ChevronRight className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(app)/monthly/page.tsx
+++ b/src/app/(app)/monthly/page.tsx
@@ -1,0 +1,142 @@
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import MonthlyHeader from "./_components/MonthlyHeader";
+import DataSourceFilter from "./_components/DataSourceFilter";
+import MonthlyClientShell from "./_components/MonthlyClientShell";
+
+export type ChartEntry = {
+  categoryId: number | null;
+  name: string;
+  amount: number;
+  percentage: number;
+};
+
+export type TransactionItem = {
+  id: number;
+  usageDate: Date;
+  amount: number;
+  description: string;
+  type: string;
+  categoryId: number | null;
+  category: { id: number; name: string } | null;
+  dataSource: { id: number; name: string } | null;
+};
+
+export default async function MonthlyPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ year?: string; month?: string; dataSources?: string }>;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/auth/signin");
+
+  const { year, month, dataSources } = await searchParams;
+
+  const dsIds = dataSources
+    ? dataSources.split(",").map(Number).filter((n) => !isNaN(n) && n > 0)
+    : [];
+
+  // year/month が両方指定済みならクエリ不要。未指定時のみ最新日付を取得
+  let resolvedYear: number;
+  let resolvedMonth: number;
+  if (year && month) {
+    resolvedYear = parseInt(year, 10);
+    resolvedMonth = parseInt(month, 10);
+  } else {
+    const latestTx = await prisma.transaction.findFirst({
+      orderBy: { usageDate: "desc" },
+      select: { usageDate: true },
+    });
+    const d = latestTx?.usageDate ?? new Date();
+    resolvedYear = year ? parseInt(year, 10) : d.getFullYear();
+    resolvedMonth = month ? parseInt(month, 10) : d.getMonth() + 1;
+  }
+
+  const start = new Date(resolvedYear, resolvedMonth - 1, 1);
+  const end = new Date(resolvedYear, resolvedMonth, 1);
+
+  const [transactions, allDataSources] = await Promise.all([
+    prisma.transaction.findMany({
+      where: {
+        usageDate: { gte: start, lt: end },
+        type: { not: "transfer" },
+        ...(dsIds.length > 0 ? { dataSourceId: { in: dsIds } } : {}),
+      },
+      select: {
+        id: true,
+        usageDate: true,
+        amount: true,
+        description: true,
+        type: true,
+        categoryId: true,
+        category: { select: { id: true, name: true } },
+        dataSource: { select: { id: true, name: true } },
+      },
+      orderBy: { usageDate: "desc" },
+    }),
+    prisma.dataSource.findMany({ orderBy: { name: "asc" } }),
+  ]);
+
+  const expenseTransactions = transactions.filter(
+    (t) => t.type === "expense" && t.amount > 0
+  );
+  const totalExpense = expenseTransactions.reduce((sum, t) => sum + t.amount, 0);
+  const totalIncome = transactions
+    .filter((t) => t.type === "income")
+    .reduce((sum, t) => sum + Math.abs(t.amount), 0);
+
+  const amountByCategory = new Map<number | null, { name: string; amount: number }>();
+  for (const t of expenseTransactions) {
+    const key = t.categoryId;
+    const current = amountByCategory.get(key) ?? {
+      name: t.category?.name ?? "未分類",
+      amount: 0,
+    };
+    amountByCategory.set(key, { name: current.name, amount: current.amount + t.amount });
+  }
+
+  const chartData: ChartEntry[] = [...amountByCategory.entries()]
+    .map(([categoryId, { name, amount }]) => ({
+      categoryId,
+      name,
+      amount,
+      percentage: totalExpense > 0 ? Math.round((amount / totalExpense) * 100) : 0,
+    }))
+    .sort((a, b) => b.amount - a.amount);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h1 className="text-2xl font-bold">月別サマリー</h1>
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <span className="text-muted-foreground">{transactions.length} 件</span>
+          {totalExpense > 0 && (
+            <span className="font-medium text-destructive">
+              支出合計: ¥{totalExpense.toLocaleString()}
+            </span>
+          )}
+          {totalIncome > 0 && (
+            <span className="font-medium text-green-600">
+              収入合計: ¥{totalIncome.toLocaleString()}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <MonthlyHeader
+          year={resolvedYear}
+          month={resolvedMonth}
+          dataSources={dataSources ?? ""}
+        />
+        <DataSourceFilter
+          allDataSources={allDataSources}
+          selectedIds={dsIds}
+          year={resolvedYear}
+          month={resolvedMonth}
+        />
+      </div>
+      <MonthlyClientShell chartData={chartData} transactions={transactions} />
+    </div>
+  );
+}

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Upload, List, Wallet, Building2, Settings, Database, Package, Bot, Palette } from "lucide-react";
+import { Home, Upload, List, Wallet, Building2, Settings, Database, Package, Bot, Palette, BarChart2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const links = [
   { label: "ホーム", icon: Home, href: "/", implemented: true },
   { label: "CSVインポート", icon: Upload, href: "/import", implemented: true },
   { label: "明細一覧", icon: List, href: "/transactions", implemented: true },
+  { label: "月別サマリー", icon: BarChart2, href: "/monthly", implemented: true },
   { label: "精算", icon: Wallet, href: "/settlement", implemented: true },
   { label: "ローン管理", icon: Building2, href: "/loans", implemented: true },
   { label: "カテゴリ管理", icon: Settings, href: "/settings/categories", implemented: true },


### PR DESCRIPTION
## Summary

- `/monthly` ページを新規追加（issue #22）
- カテゴリ別支出の横棒グラフ（Recharts）でバークリック → 明細ドリルダウン
- 前月/次月ナビゲーション（URL searchParams で状態管理）
- DataSource マルチセレクトフィルタ（Popover + Checkbox）
- NavLinks に「月別サマリー」（BarChart2 アイコン）を追加

## 実装詳細

| ファイル | 役割 |
|---------|------|
| `monthly/page.tsx` | Server Component。year/month 指定済み時は latestTx クエリをスキップして高速化 |
| `_components/MonthlyHeader.tsx` | 前月/次月ナビ（URLパラメータ保持） |
| `_components/DataSourceFilter.tsx` | マルチセレクト DataSource フィルタ |
| `_components/MonthlyClientShell.tsx` | selectedCategoryId state 管理 |
| `_components/CategoryBreakdownChart.tsx` | クリック選択可能な横棒グラフ（金額+%ラベル付き） |
| `_components/CategoryTransactionTable.tsx` | 選択カテゴリの明細（モバイルカード/デスクトップテーブル） |

## Test plan

- [ ] `/monthly` にアクセス → 最新月のデータが表示される
- [ ] 前月/次月ボタン → URL が変わり、対応月データが表示される
- [ ] DataSource フィルタで選択/解除 → 集計値とグラフが変わる
- [ ] グラフのバーをクリック → 明細テーブルが表示され金額降順に並ぶ
- [ ] 同じバーを再クリック → テーブルが非表示になる
- [ ] type="transfer" のトランザクションがグラフに含まれていないことを確認
- [ ] モバイル幅（375px）でレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monthly financial summary page displaying expense breakdown by category
  * Interactive bar chart visualizing category expenses with percentage amounts
  * Data source filtering for monthly analytics
  * Transaction detail viewer for selected categories
  * Month-to-month navigation controls
  * Added "Monthly Summary" link to main navigation menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->